### PR TITLE
Mobile version of the site

### DIFF
--- a/src/components/ui/Sidebar.astro
+++ b/src/components/ui/Sidebar.astro
@@ -13,46 +13,226 @@ const url = Astro.url.pathname.replaceAll("/", "");
 const titleString = titles[url as keyof typeof titles] || "stuff";
 ---
 
-<div class="wrapper">
-  <ThemeToggle />
-  <p class="title">
-    I am <span>angelo</span><br />and I do <br /><i>{titleString}</i>
-  </p>
-  <Navigation />
+<div class="wrapper" id="sidebar">
+  <div class="bar">
+    <p class="title">
+      I am <span>angelo</span> <br class="br-wide" />and <br
+        class="br-narrow"
+      />I do <br class="br-wide" /><i>{titleString}</i>
+    </p>
 
-  <div class="social">
-    <a
-      href="https://www.linkedin.com/in/angelod1as/"
-      class="external-link"
-      rel="noopener noreferrer"
-      target="_blank">LinkedIn<span> ➹</span></a
+    <button
+      id="menu-toggle"
+      class="menu-toggle"
+      type="button"
+      aria-expanded="false"
+      aria-controls="menu-panel"
+      aria-label="Toggle menu"
     >
-    <a
-      href="https://github.com/angelod1as"
-      class="external-link"
-      rel="noopener noreferrer"
-      target="_blank">GitHub<span> ➹</span></a
-    >
+      <svg
+        class="icon-closed"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        aria-hidden="true"
+      >
+        <path d="M3 6h18M3 12h18M3 18h18"></path>
+      </svg>
+      <svg
+        class="icon-open"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        aria-hidden="true"
+      >
+        <path d="M6 6l12 12M18 6L6 18"></path>
+      </svg>
+    </button>
+  </div>
+
+  <div class="panel" id="menu-panel">
+    <div class="menu-col">
+      <Navigation />
+
+      <div class="social">
+        <a
+          href="https://www.linkedin.com/in/angelod1as/"
+          class="external-link"
+          rel="noopener noreferrer"
+          target="_blank">LinkedIn<span> ➹</span></a
+        >
+        <a
+          href="https://github.com/angelod1as"
+          class="external-link"
+          rel="noopener noreferrer"
+          target="_blank">GitHub<span> ➹</span></a
+        >
+      </div>
+    </div>
+
+    <div class="theme-col">
+      <ThemeToggle />
+    </div>
   </div>
 </div>
 
+<script>
+  const wrapper = document.getElementById("sidebar");
+  const toggle = document.getElementById("menu-toggle");
+
+  wrapper?.setAttribute("data-js", "");
+
+  const close = () => {
+    wrapper?.removeAttribute("data-open");
+    toggle?.setAttribute("aria-expanded", "false");
+  };
+
+  toggle?.addEventListener("click", () => {
+    const open = wrapper?.toggleAttribute("data-open");
+    toggle.setAttribute("aria-expanded", String(open));
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape" || !wrapper?.hasAttribute("data-open")) return;
+    close();
+    toggle?.focus();
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!wrapper?.hasAttribute("data-open")) return;
+    if (wrapper.contains(event.target as Node)) return;
+    close();
+  });
+</script>
+
 <style>
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
   .title {
     font-family: var(--font-display);
     line-height: 100%;
     margin: 0;
-    font-size: 2.5rem;
+    font-size: 1.25rem;
   }
-  .wrapper {
-    display: flex;
-    height: 100%;
-    flex-direction: column;
-    gap: 2rem;
+
+  .br-wide {
+    display: none;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+    align-items: center;
     justify-content: center;
+    flex-shrink: 0;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+    border: 3px solid var(--border);
+    cursor: pointer;
+    transform: translate(var(--lift), calc(var(--lift) * -1));
+    box-shadow: calc(var(--lift) * -1) var(--lift) 0 var(--accent);
+    transition:
+      transform 180ms ease,
+      box-shadow 180ms ease;
   }
+
+  .menu-toggle:active {
+    transform: translate(0, 0);
+    box-shadow: 0 0 0 var(--accent);
+    transition-duration: 80ms;
+  }
+
+  .menu-toggle .icon-open,
+  .wrapper[data-open] .menu-toggle .icon-closed {
+    display: none;
+  }
+
+  .wrapper[data-open] .menu-toggle .icon-open {
+    display: block;
+  }
+
+  .panel {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .menu-col {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .wrapper[data-js] .panel {
+    display: none;
+  }
+
+  .wrapper[data-js][data-open] .panel {
+    display: flex;
+  }
+
   .social {
     display: flex;
     flex-direction: column;
     font-size: 0.9rem;
+  }
+
+  @media (min-width: 768px) {
+    .wrapper {
+      height: 100%;
+      justify-content: center;
+      gap: 2rem;
+    }
+
+    .panel,
+    .wrapper[data-js] .panel {
+      display: contents;
+    }
+
+    .menu-col {
+      gap: 2rem;
+    }
+
+    .theme-col {
+      order: -1;
+    }
+
+    .title {
+      font-size: 2.5rem;
+    }
+
+    .br-wide {
+      display: revert;
+    }
+
+    .br-narrow {
+      display: none;
+    }
+
+    .menu-toggle {
+      display: none;
+    }
   }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -46,7 +46,7 @@ const ogImage = new URL(image ?? "/og.png", Astro.site).href;
 
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>
     <link rel="canonical" href={canonical} />
@@ -87,32 +87,52 @@ const ogImage = new URL(image ?? "/og.png", Astro.site).href;
   .body {
     margin: 0 auto;
     width: 100%;
-    height: 100%;
     min-height: 100vh;
+    min-height: 100dvh;
 
-    /* Desktop */
-    display: grid;
-    grid-template-columns: 1fr 3fr;
-    gap: 1rem;
+    display: flex;
+    flex-direction: column;
   }
 
   .header {
     /* Position */
     position: sticky;
     top: 0;
-    height: 100dvh;
-    overflow: auto;
-    padding: 1rem;
-    border-right: 1px solid var(--border);
+    z-index: 10;
+    background-color: var(--bg);
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border);
   }
 
   .main {
+    width: 100%;
     max-width: 800px;
-    margin: 0 auto;
-    margin: 10rem 0;
+    margin: 2rem auto;
     padding: 1rem;
     display: flex;
     flex-direction: column;
     gap: 2rem;
+  }
+
+  /* Desktop */
+  @media (min-width: 768px) {
+    .body {
+      height: 100%;
+      display: grid;
+      grid-template-columns: 1fr 3fr;
+      gap: 1rem;
+    }
+
+    .header {
+      height: 100dvh;
+      overflow: auto;
+      padding: 1rem;
+      border-right: 1px solid var(--border);
+      border-bottom: 0;
+    }
+
+    .main {
+      margin: 10rem 0;
+    }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,15 +76,20 @@ const allProjects = [...highlighted, ...rest].slice(0, 3);
 <style>
   .wrapper {
     display: grid;
-    grid-template-columns: 2fr 1fr;
     gap: 3rem;
+  }
 
-    > * {
-      grid-column: 1;
-    }
+  @media (min-width: 768px) {
+    .wrapper {
+      grid-template-columns: 2fr 1fr;
 
-    > .full {
-      grid-column: 1 / -1;
+      > * {
+        grid-column: 1;
+      }
+
+      > .full {
+        grid-column: 1 / -1;
+      }
     }
   }
 

--- a/src/pages/more.astro
+++ b/src/pages/more.astro
@@ -12,11 +12,11 @@ const title = "I am angelo and here's more";
 
 <BaseLayout title={title}>
   <div class="wrapper">
-    <div class="more"><IAm /></div>
-    <div class="more"><IWant /></div>
-    <div class="more"><IWas /></div>
-    <div class="experience"><Experience /></div>
-    <div class="more"><Colophon /></div>
+    <div class="more prose"><IAm /></div>
+    <div class="more prose"><IWant /></div>
+    <div class="more prose"><IWas /></div>
+    <div class="experience prose"><Experience /></div>
+    <div class="more prose"><Colophon /></div>
   </div>
 </BaseLayout>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,7 +32,13 @@ html {
   background-color: var(--bg);
   color: var(--fg);
   font-family: var(--font-text), sans-serif;
-  font-size: 125%;
+  font-size: 100%;
+}
+
+@media (min-width: 768px) {
+  html {
+    font-size: 125%;
+  }
 }
 
 body {
@@ -51,7 +57,7 @@ img {
 /* Typography */
 
 h1 {
-  font-size: 2.5rem;
+  font-size: clamp(1.75rem, 9vw, 2.5rem);
 }
 
 h1,
@@ -217,6 +223,7 @@ code {
 pre {
   padding: 1rem;
   border-radius: 3px;
+  overflow-x: auto;
 }
 
 /* WIP and DRAFT Pill indicator */


### PR DESCRIPTION
The site had no responsive rules at all — the only `@media` query in the codebase was `prefers-reduced-motion`. On a phone the `1fr 3fr` grid gave the sidebar a full-height column and the theme was sized for a desktop reading distance. This adds a mobile layout, mobile-first, with the existing desktop composition preserved behind `min-width: 768px`.

## What changed

- **Type** — base font size starts at 100% and bumps to 125% from 768px up, so the desktop reading size is unchanged. `h1` uses `clamp(1.75rem, 9vw, 2.5rem)` because 2.5rem overflows a 375px viewport on long titles. `pre` scrolls horizontally instead of widening the page.
- **Layout** — `body` is a flex column by default and becomes the `1fr 3fr` grid at 768px. The header is a slim sticky bar on mobile with an opaque background and a bottom border; it keeps its full-height sticky column on desktop. Added `initial-scale=1` to the viewport meta.
- **Sidebar** — splits into a `.bar` (title + menu button) and a `#menu-panel` drawer (nav, socials, theme toggle). The drawer is a two-column row: nav on the left, theme toggle pinned top-right under the hamburger. On desktop the panel is `display: contents`, which flattens it so the toggle, title, nav and socials sit in the sidebar column exactly as before, evenly 2rem apart.
- **Title** — two sets of `<br>`. Narrow screens break after "and" (`I am angelo and / I do stuff`) so a long page title like "even more!" keeps its own line; desktop keeps the original three-line composition.
- **Home page** — the `2fr 1fr` grid and its `grid-column` rules moved into the desktop media query, so content uses the full width on mobile.
- **More page** — sections get the `prose` class for consistent vertical spacing.

## Notes

- Collapsing the drawer is opt-in via a `data-js` attribute the script sets on load, so if the script fails the nav renders expanded and stays reachable rather than being hidden with no way to open it.
- The menu button toggles `aria-expanded` and points at the drawer with `aria-controls`. Escape and an outside click both close it.
- Breakpoint is 768px throughout, matching the existing unused `--w-md` token.

## Testing

- `pnpm build` — 41 pages, clean
- `pnpm test` — 47 tests pass
- Manually checked at 375px and 390px against desktop for `/`, `/blog/`, a post, `/projects/`, `/recommendations/`, `/more/`